### PR TITLE
Use data() instead of begin() when reading file memory region

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -23,7 +23,7 @@ memory::ArrayMemoryRegion<24 >* createFileMemoryRegion(const char* fileName) {
 	size_t fileSize = ftell(f);
 	fseek(f, 0, SEEK_SET);
 
-	if(fread(result->memory.begin(), 1, fileSize, f) != fileSize)
+	if(fread(result->memory.data(), 1, fileSize, f) != fileSize)
 		fprintf(stderr, "WARNING: Bad firmware\n");
 
 	fclose(f);


### PR DESCRIPTION
Mostly just a test but I do believe it should be data() not begin() 